### PR TITLE
fixed logical bug on 2 specs in queryTests.js

### DIFF
--- a/net/DocCode/DocCode/tests/queryTests.js
+++ b/net/DocCode/DocCode/tests/queryTests.js
@@ -546,8 +546,8 @@
         
         stop();
 
-        // all should return exactly 15 orders
-        runQuery(em, query, "AND orders query", 15)
+        // all should return exactly 16 orders
+        runQuery(em, query, "AND orders query", 16)
         .fail(handleFail)
         .fin(start);
     });
@@ -581,8 +581,8 @@
 
         stop();
 
-        // all should return exactly 256 orders
-        runQuery(em, query, "OR orders query", 256)
+        // all should return exactly 259 orders
+        runQuery(em, query, "OR orders query", 259)
         .fail(handleFail)
         .fin(start);
     });


### PR DESCRIPTION
Test fails in queryTests.js on both specs:
"on orders ordered after April '98 OR with freight > 100"
"orders ordered after April '98 AND with freight > 100"
The they're failing because `JavaScript Date.toISOString()` method
is somewhat ambiguous:
new Date(1998, 3, 1).toISOString() returns "1998-03-31T22:00:00.000Z"
This means that orders with OrderDate = "1998-04-01" are also included
with the queries.

To test this claim run this SQL on the server:
`SELECT * FROM [Northwind].[dbo].[Order] where Freight > 100 and
OrderDate > '1998-03-31T22:00:00.000Z'`
This query should return 16 instead of 15 records.
