### PR TITLE
Remove unnecessary use of TaskCompletionSource<T>.

### DIFF
--- a/net/Todo-Angular/Todo-Angular/App_Start/BreezeSimpleCorsHandler.cs
+++ b/net/Todo-Angular/Todo-Angular/App_Start/BreezeSimpleCorsHandler.cs
@@ -78,9 +78,7 @@ namespace Breeze.WebApi
 
                     response.Headers.Add(AccessControlAllowCredentials, "true");
 
-                    var tcs = new TaskCompletionSource<HttpResponseMessage>();
-                    tcs.SetResult(response);
-                    return tcs.Task;
+                    return Task.FromResult(response);
                 }
                 return base.SendAsync(request, cancellationToken).ContinueWith(t =>
                     {

--- a/net/Todo-Knockout-Require/Todo-Knockout/App_Start/BreezeSimpleCorsHandler.cs
+++ b/net/Todo-Knockout-Require/Todo-Knockout/App_Start/BreezeSimpleCorsHandler.cs
@@ -78,9 +78,7 @@ namespace Breeze.WebApi
 
                     response.Headers.Add(AccessControlAllowCredentials, "true");
 
-                    var tcs = new TaskCompletionSource<HttpResponseMessage>();
-                    tcs.SetResult(response);
-                    return tcs.Task;
+                    return Task.FromResult(response);
                 }
                 return base.SendAsync(request, cancellationToken).ContinueWith(t =>
                     {

--- a/net/Todo-Knockout/Todo-Knockout/App_Start/BreezeSimpleCorsHandler.cs
+++ b/net/Todo-Knockout/Todo-Knockout/App_Start/BreezeSimpleCorsHandler.cs
@@ -78,9 +78,7 @@ namespace Breeze.WebApi
 
                     response.Headers.Add(AccessControlAllowCredentials, "true");
 
-                    var tcs = new TaskCompletionSource<HttpResponseMessage>();
-                    tcs.SetResult(response);
-                    return tcs.Task;
+                    return Task.FromResult(response);
                 }
                 return base.SendAsync(request, cancellationToken).ContinueWith(t =>
                     {


### PR DESCRIPTION
The use of TaskCompletionSource<T> in the examples in unnecessarily complicated. Task.FromResult() is a better fit. 
