### PR TITLE
Correctly check for PropertyChange action

### DIFF
--- a/no-server/todo-zumo/app/wip-service.js
+++ b/no-server/todo-zumo/app/wip-service.js
@@ -30,7 +30,7 @@
         var eventName = "WIP";
         var isRestoring = false;
         var manager = undefined;
-        var propChangeAction = breeze.PropertyChange;
+        var propChangeAction = breeze.EntityAction.PropertyChange;
         var priorTimeout = undefined;
         var stashName = "wip";
         var stashTypes = [];
@@ -53,7 +53,7 @@
 
         function entityChanged(changeArgs){
             if (isRestoring || stopped) {return;} // ignore WIP service's own changes.
-            var action = changeArgs.action;
+            var action = changeArgs.entityAction;
 
 
             if (action === propChangeAction ){


### PR DESCRIPTION
Currently the check for propertyChange is not working (It compares twice undefined). This PR fixes this. But as consequence stashing no longer happens for newly created ToDo entities, since for them no propertyChange event is raised.
