### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#About the Breeze JS Samples
+# About the Breeze JS Samples
 
 The *Breeze JavaScript client samples* demonstrate BreezeJS in action in different technology environments. They are (almost) all maintained by the Breeze core team.
 

--- a/java/TodoAngular/readme.md
+++ b/java/TodoAngular/readme.md
@@ -1,4 +1,4 @@
-#Todo Angular Hibernate
+# Todo Angular Hibernate
 The "Todo Angular Hibernate" sample app is a single page application (SPA) built with Breeze, Angular, and Hibernate. Instructions to install and run follow.
 
 ## Prerequisites
@@ -7,7 +7,7 @@ The "Todo Angular Hibernate" sample app is a single page application (SPA) built
 * [Apache Tomcat](http://tomcat.apache.org/)
 * [MySql](http://www.mysql.com)
 
-##Download samples
+## Download samples
 
 Download [ALL of the Breeze JavaScript samples from github](https://github.com/Breeze/breeze.js.samples "breeze.js.samples on github")
 as [a zip file](https://github.com/Breeze/breeze.js.samples/archive/master.zip "breeze.js.samples zip file").
@@ -15,13 +15,13 @@ as [a zip file](https://github.com/Breeze/breeze.js.samples/archive/master.zip "
 In this case we're interested in the "TodoAngular" sample, located in the *java/TodoAngular* directory.
 These instructions assume this will be your current working directory.
 
-##Install MySql and run database scripts
+## Install MySql and run database scripts
 
 Run the *~/java/TodoAngular/db\_script/init\_todos.sql* script to create the 'todos' database.
 
 Run the *~/java/TodoAngular/db\_script/create\_demo\_user.sql* script to create the 'demo' user and grant it permission to the 'todos' database.
 
-##Build and deploy
+## Build and deploy
 
 We'll be building the project with Maven and deploying it with Apache Tomcat. We have provided build scripts to make the build and deployment process easier.
 
@@ -30,6 +30,6 @@ We'll be building the project with Maven and deploying it with Apache Tomcat. We
 3. Modify the two path variables, MAVEN\_REPO and CATALINA\_HOME accordingly
 4. Run the *build.bat* script
 
-##Launch Todo-Angular in a browser
+## Launch Todo-Angular in a browser
 
 Start your browser with address [**http://localhost:8080/TodoAngular**](http://localhost:8080/TodoAngular)

--- a/net/ngNorthwind/README.md
+++ b/net/ngNorthwind/README.md
@@ -1,4 +1,4 @@
-#Breeze Angular Northwind Demo
+# Breeze Angular Northwind Demo
 
 ## Structure
 

--- a/no-server/edmunds/README.md
+++ b/no-server/edmunds/README.md
@@ -15,7 +15,7 @@ Just some HTML and JavaScript on the client talking to a public 3rd party API th
 
 Here's what you need to know to get it going.
 
-##Prep It
+## Prep It
 
 The breeze scripts are not included directly in this sample. You must copy them into the sample before you run it.
 
@@ -27,7 +27,7 @@ Not a Windows user? It's really simple.
 * Notice that it copies a small number of source files, starting from  <em>..\..\build\libs\</em>,  into the  *scripts*  folder.
 * Do the same manually.
 
-##Run it
+## Run it
 
 Locate the index.html file. Double-click it. The app loads in your default browser.
 

--- a/no-server/todo-zumo/README.md
+++ b/no-server/todo-zumo/README.md
@@ -30,7 +30,7 @@ The **Breeze** features of particular interest are:
 
 * Defining Breeze metadata on the client instead (both servers).
 
-#Installation
+# Installation
 
 The breeze scripts are not included directly in this sample. You must copy them into the sample before you run it.
 
@@ -47,7 +47,7 @@ Not a Windows user? It's pretty simple.
 
 >If you want to run the *Web API server* variation, continue with the Web API server installation instructions [below](#WebAPI).
 
-#Run
+# Run
 
 You'll need to launch a web application server to host the client-side assets (HTML, CSS, JavaScript).
 
@@ -79,11 +79,11 @@ Notice that
 * <span style="color:red;">Red error messages</span> (not shown) appear below the blue WIP messages when something goes wrong ... such as trying to save a TodoItem that has no description.
 
 <a name="WebAPI"></a>
-#The Web API Option
+# The Web API Option
 
 If you're on a Windows .NET 4.5 machine you can reconfigure the app to talk to a local ASP.NET Web API service.
 
-##Install the Web API server
+## Install the Web API server
 
 You'll have to build ASP.NET Web API server first before re-targeting the application to that server. Here's how:
 
@@ -91,7 +91,7 @@ You'll have to build ASP.NET Web API server first before re-targeting the applic
 2. Launch the *todo.sln* in Visual Studio
 3. Build it (ctrl-shift-B); it should download the requisite nuget packages during the build process.
 
-##Run with a Web API server
+## Run with a Web API server
 You can run this server in Visual Studio, either with or without debug. But you don't have to. Once built, you can close Visual Studio and you needn't open it again. Instead, do as follows:
 
 1. Open the *launchers* folder.

--- a/node/ngDocCode/README.md
+++ b/node/ngDocCode/README.md
@@ -66,7 +66,7 @@ to the command as in:
 
 Web Storm is a nice IDE for development and debugging. You can run the tests inside Web Storm with Karma or as a Node application.
 
-####Run with Karma
+#### Run with Karma
 
 1. Create a Web Storm configuration for "karma" (one time setup)
 

--- a/node/tempHire/readme.md
+++ b/node/tempHire/readme.md
@@ -1,11 +1,11 @@
-#TempHire Sequelize
+# TempHire Sequelize
 The "TempHire Sequelize" sample app is a single page application (SPA) built with Breeze, Angular, Node, Express, Sequelize and MySql. Instructions to install and run follow.
 
 ## Prerequisites
 * Node.js >=0.10
 * [MySql](http://www.mysql.com)
 
-##Download samples
+## Download samples
 
 Download [ALL of the Breeze JavaScript samples from github](https://github.com/Breeze/breeze.js.samples "breeze.js.samples on github")
 as [a zip file](https://github.com/Breeze/breeze.js.samples/archive/master.zip "breeze.js.samples zip file").
@@ -13,11 +13,11 @@ as [a zip file](https://github.com/Breeze/breeze.js.samples/archive/master.zip "
 In this case we're interested in the "tempHire" sample, located in the *node/tempHire* directory.
 These instructions assume this will be your current working directory.
 
-##Install MySql and run sql script to create demo user
+## Install MySql and run sql script to create demo user
 
 Run the *~/node/tempHire/db-script/create-temphire-user.sql* script
 
-##Install dependencies and launch app server
+## Install dependencies and launch app server
 
 Navigate to the server folder, *~/node/tempHire/server*
 
@@ -27,6 +27,6 @@ Install dependencies and launch the app server: `npm start`
 
 Console output should indicate that app server started successfully and is **listening on port 3000**.
 
-##Launch TempHire in a browser
+## Launch TempHire in a browser
 
 Start your browser with address [**http://localhost:3000**](http://localhost:3000)

--- a/node/todo-angular/readme.md
+++ b/node/todo-angular/readme.md
@@ -1,4 +1,4 @@
-#Todo Angular Sequelize
+# Todo Angular Sequelize
 The "Todo Angular Sequelize" sample app is a single page application (SPA) built with Breeze, Angular, Node, Express, and Sequelize. Currently, this sample can be run with either a MySql or a PostgreSQL database. Instructions to install and run follow.
 
 ## Prerequisites
@@ -6,7 +6,7 @@ The "Todo Angular Sequelize" sample app is a single page application (SPA) built
 * [MySql](http://www.mysql.com) or
 * [PostgreSQL](http://www.postgresql.org)
 
-##Download samples
+## Download samples
 
 Download [ALL of the Breeze JavaScript samples from github](https://github.com/Breeze/breeze.js.samples "breeze.js.samples on github")
 as [a zip file](https://github.com/Breeze/breeze.js.samples/archive/master.zip "breeze.js.samples zip file").
@@ -14,13 +14,13 @@ as [a zip file](https://github.com/Breeze/breeze.js.samples/archive/master.zip "
 In this case we're interested in the "todo-angular" sample, located in the *node/todo-angular* directory.
 These instructions assume this will be your current working directory.
 
-##Install MySql and run sql script to create demo user
+## Install MySql and run sql script to create demo user
 
 Run the *~/node/todo-angular/db-script/mysql/create-demo-user.sql* script
 
 **OR**
 
-##Install PostgreSQL and run the following sql scripts in order
+## Install PostgreSQL and run the following sql scripts in order
 
 Run the *~/node/todo-angular/db-script/postgres/#1 - create-demo-user.sql* script
 
@@ -34,11 +34,11 @@ Switch the current connection to the new `todos` database by creating a new conn
 
 Run the *~/node/todo-angular/db-script/postgres/#3 - init-todos-table.sql* script
 
-##Instructing Breeze to use PostgreSQL
+## Instructing Breeze to use PostgreSQL
 
 By default, the server will connect to a MySql db instance. If you want  the server to connect to a Postgres instance, you can toggle the flag located at [routes.js](https://github.com/Breeze/breeze.js.samples/blob/feature/todo-angular-node-postgres/node/todo-angular/server/routes.js#L23)
 
-##Install dependencies and launch app server
+## Install dependencies and launch app server
 
 Navigate to the server folder, *~/node/todo-angular/server*
 
@@ -48,6 +48,6 @@ Install dependencies and launch the app server: `npm start`
 
 Console output should indicate that app server started successfully and is **listening on port 3000**.
 
-##Launch Todo-Angular in a browser
+## Launch Todo-Angular in a browser
 
 Start your browser with address [**http://localhost:3000**](http://localhost:3000)

--- a/node/zza-node-mongo/readme.md
+++ b/node/zza-node-mongo/readme.md
@@ -1,4 +1,4 @@
-#Zza Node Mongo
+# Zza Node Mongo
 The "Zza Node Mongo" sample app is a single page application (SPA) built with Breeze, Angular, Node, and MongoDB. Instructions to install and run follow.
 
 ## Prerequisites
@@ -6,7 +6,7 @@ The "Zza Node Mongo" sample app is a single page application (SPA) built with Br
 * <a href="http://blog.mongodb.org/post/82092813806/mongodb-2-6-our-biggest-release-ever"
   target="_blank" title="MongoDb release 2.6 announcement">MongoDb >= v.2.6</a>
 
-##Download samples
+## Download samples
 
 Download [ALL of the Breeze JavaScript samples from github](https://github.com/Breeze/breeze.js.samples "breeze.js.samples on github")
 as [a zip file](https://github.com/Breeze/breeze.js.samples/archive/master.zip "breeze.js.samples zip file").
@@ -14,7 +14,7 @@ as [a zip file](https://github.com/Breeze/breeze.js.samples/archive/master.zip "
 In this case we're interested in the "Zza" sample, located in the *node/zza-node-mongo* directory.
 These instructions assume this will be your current working directory.
 
-##Install MongoDb database and run MongoDb server
+## Install MongoDb database and run MongoDb server
 
 Unzip *~/database/zza-mongo-database.zip* into the *database* directory.
 
@@ -28,7 +28,7 @@ Start mongodb server while pointing to this database directory. On my windows ma
 
 Console output should indicate that MongoDb server started successfully and is listening on port 27017 (or adjust the `mongodbUrl` in `~\server\database.js` to the appropriate port).
 
-##Install dependencies and launch app server
+## Install dependencies and launch app server
 
 Open a second command / terminal window
 
@@ -46,7 +46,7 @@ Launch the app server: `node server.js`
 
 Console output should indicate that app server started successfully and is **listening on port 3000**.
 
-##Launch Zza in a browser
+## Launch Zza in a browser
 
 Start your browser with address [**http://localhost:3000**](http://localhost:3000)
 

--- a/ruby/CCJS-Ruby/readme.md
+++ b/ruby/CCJS-Ruby/readme.md
@@ -1,5 +1,5 @@
 
-#CCJS - Ruby on Rails
+# CCJS - Ruby on Rails
 
 This sample illustrates a BreezeJS client working with a Ruby on Rails backend. 
 
@@ -7,15 +7,15 @@ The [Breeze CCJS-Ruby sample documentation](http://breeze.github.io/doc-samples/
 
 There are two main directories, "client" and "rails".
 
-###client
+### client
 The client app (CCJS) is derived from the published source code for John Papa's "Code Camper Jumpstart". Learn about CCJS in his justly famous PluralSight course, ["Single Page Apps JumpStart"](http://pluralsight.com/training/Courses/TableOfContents/single-page-apps-jumpstart)
 
 It has been modified in small but important ways to interact with a Rails backend instead of the ASP.NET Web API backend in the original. In all other respects (except the ruby re-coloring), it is the same as the original. John's course is the best guide to it's behavior and implementation.
 
-###rails
+### rails
 This "rails" directory holds the Ruby on Rails code and database data for the CCJS-Ruby sample.
 
-###prerequisites
+### prerequisites
 We assume you are familiar with Ruby and have Rails, MySql, and some kind of web server installed in your environment. 
 
 There are four principle steps to running the application.
@@ -25,7 +25,7 @@ There are four principle steps to running the application.
 3. Start client app server
 4. Launch app in a browser
 
-#Setup 
+# Setup 
 
 You only perform this step once.
 
@@ -53,7 +53,7 @@ f.  Import Data as follows, replacing [user] with your MySQL user (e.g., admin);
 
 >if mysql is not in your path, specify the full executable path, e.g. *C:/Program Files/MySQL/MySQL Server 5.5/bin/mysql*
 
-#Start the rails server
+# Start the rails server
 
 **Make sure nothing else is running on port 3000!**
 
@@ -63,7 +63,7 @@ Go to the *~/ccjs_ruby/rails* directory if you're not already there. In a termin
 
 The rails **server** is running on port **3000**
 
-#Start the client application server
+# Start the client application server
 
 Most of the client application assets - html, css, JavaScript - are in the *~/ccjs_ruby/client* directory.
 
@@ -87,6 +87,6 @@ Here is an example running in Python.
 
 The **client** application server is now running on port **8000**
 
-#Launch the app in your browser
+# Launch the app in your browser
 
 Open a browser to **http://localhost:8000/**


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
